### PR TITLE
fix: remove babel-plugin-transform-react-constant-elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ function addReactSupport(config, options) {
     if (options.env === 'production') {
         config.plugins.push(
             require.resolve('babel-plugin-transform-react-remove-prop-types'),
-            require.resolve('babel-plugin-transform-react-constant-elements'),
             require.resolve('babel-plugin-transform-react-inline-elements')
         );
     // The following two plugins are currently necessary to make React warnings include more valuable information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1329,14 +1329,6 @@
         "babel-runtime": "6.26.0"
       }
     },
-    "babel-plugin-transform-react-constant-elements": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-constant-elements/-/babel-plugin-transform-react-constant-elements-6.23.0.tgz",
-      "integrity": "sha1-LxGb9NLN1F65uqrldAU8YE9hR90=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
     "babel-plugin-transform-react-display-name": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "babel-plugin-syntax-jsx": "^6.18.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-plugin-transform-react-constant-elements": "^6.23.0",
     "babel-plugin-transform-react-display-name": "^6.25.0",
     "babel-plugin-transform-react-inline-elements": "^6.22.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -520,7 +520,6 @@ Object {
       },
     ],
     "<PROJECT_ROOT>/node_modules/babel-plugin-transform-react-remove-prop-types/lib/index.js",
-    "<PROJECT_ROOT>/node_modules/babel-plugin-transform-react-constant-elements/lib/index.js",
     "<PROJECT_ROOT>/node_modules/babel-plugin-transform-react-inline-elements/lib/index.js",
     Array [
       "<PROJECT_ROOT>/node_modules/babel-plugin-lodash/lib/index.js",


### PR DESCRIPTION
Remove babel-plugin-transform-react-constant-elements, since this plugin is still buggy and also is not the best solution because it moves the cost to initialization time, potentially hurting the TTI. Check this [issue](https://github.com/facebook/create-react-app/issues/553).